### PR TITLE
fix: drop the fake npx command from the contact page

### DIFF
--- a/app/components/notebook/sections/ContactPage.tsx
+++ b/app/components/notebook/sections/ContactPage.tsx
@@ -69,7 +69,7 @@ export default function ContactPage({ personalInfo }: { personalInfo: ResumeData
           </span>
         </div>
 
-        <p className="nb-hand mt-[var(--nb-line)] text-[18px] leading-[var(--nb-line)] text-[var(--nb-ink-soft)]">
+        <p className="nb-hand nb-t-lg mt-[var(--nb-line)] text-[var(--nb-ink-soft)]">
           usually replies within a day
         </p>
 

--- a/app/components/notebook/sections/ContactPage.tsx
+++ b/app/components/notebook/sections/ContactPage.tsx
@@ -69,11 +69,8 @@ export default function ContactPage({ personalInfo }: { personalInfo: ResumeData
           </span>
         </div>
 
-        <p className="nb-mono mt-[var(--nb-line)] leading-[var(--nb-line)] text-[var(--nb-ink-soft)]">
-          $ npx hire-abdullah
-          <span className="nb-caret" aria-hidden="true" />
-          <br />
-          <span className="opacity-60"># usually replies within a day</span>
+        <p className="nb-hand mt-[var(--nb-line)] text-[18px] leading-[var(--nb-line)] text-[var(--nb-ink-soft)]">
+          usually replies within a day
         </p>
 
         <div className="nb-nosplit mt-[var(--nb-line)]">

--- a/app/notebook.css
+++ b/app/notebook.css
@@ -1331,21 +1331,6 @@ html[data-nb-visited] .nb-leftpage {
   color: var(--nb-ink-soft);
 }
 
-.nb-mono {
-  font-family: var(--font-geist-mono), monospace;
-  font-size: 14px;
-}
-
-.nb-caret {
-  display: inline-block;
-  width: 9px;
-  height: 17px;
-  margin-left: 3px;
-  vertical-align: -2px;
-  background: var(--nb-ink);
-  animation: nb-caret 1.1s steps(1) infinite;
-}
-
 .nb-scene ::selection {
   background: var(--nb-hl-y);
 }
@@ -1411,12 +1396,6 @@ html[data-nb-visited] .nb-leftpage {
   }
   to {
     stroke-dashoffset: 0;
-  }
-}
-
-@keyframes nb-caret {
-  50% {
-    opacity: 0;
   }
 }
 


### PR DESCRIPTION
The contact page ended with a mock terminal:

```
$ npx hire-abdullah
# usually replies within a day
```

`hire-abdullah` is not a published package, so a visitor who took the invitation literally got a 404 from npm. A resume is a credibility document — it should not print a command that does not work.

## Changes

- the fake `npx` line and its blinking caret are gone
- **usually replies within a day** stays, on its own line, written in the notebook's own hand rather than left behind as an orphaned `#` shell comment
- `.nb-mono`, `.nb-caret` and the `nb-caret` keyframes are removed — that block was their only consumer, so they would otherwise be dead CSS

## Verification

- the rendered page no longer contains the string `npx hire-abdullah`
- the reply-time note occupies exactly one ruled line: 30px tall against the 30px rule, zero grid offset, set in Caveat
- `tsc --noEmit`, `eslint app` and `next build` (static export) are clean, no console errors
