### PR TITLE
fix: phones open on the identity page, and drop the page corners there

### DIFF
--- a/app/components/notebook/Notebook.tsx
+++ b/app/components/notebook/Notebook.tsx
@@ -210,22 +210,25 @@ export default function Notebook() {
       const n = Math.max(1, Math.round((flow.scrollWidth + COL_GAP) / (metrics.colw + COL_GAP)));
       next.push(n);
     });
-     
     setCounts((prev) => (prev && prev.length === next.length && prev.every((v, i) => v === next[i]) ? prev : next));
-  }, [metrics, fontsReady, sections]);
 
-  // when pagination changes, stay on the section the reader was in
-  useEffect(() => {
-    if (!counts) return;
-    const section = lastSectionRef.current;
-     
+    // Re-anchor to the section being read in the same commit as the new page
+    // count. Repagination renumbers every page, so a position kept across it
+    // points at whatever now sits at that index — correcting in a later effect
+    // renders one frame of the wrong section before it settles.
+    const nextPages = buildPages(next[0] ?? 1, next.slice(1));
+    const starts: number[] = [];
+    nextPages.forEach((page, i) => {
+      if (page.type === "content" && page.col === 0) starts[page.section] = i;
+    });
     setPos((p) => {
       if (p === 0) return p;
-      const target = sectionStart[section] ?? 1;
-      return sectionOfPage(p) === section ? p : target;
+      const section = lastSectionRef.current;
+      const at = nextPages[p];
+      if (at?.type === "content" && at.section === section) return p;
+      return starts[section] ?? 1;
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [counts]);
+  }, [metrics, fontsReady, sections]);
 
   // ---------- storage / cover ----------
   const markVisitedStorage = useCallback(() => {
@@ -353,30 +356,20 @@ export default function Notebook() {
     }
   }, [pos, stepReal]);
 
-  // Before the first paint: a phone opens on the identity page, which on a
-  // spread is the inside cover rather than a page of its own. The exported HTML
-  // cannot know the viewport, so <head> marks narrow ones and CSS holds the
-  // right page until this runs — otherwise the opening page is visibly wrong
-  // for as long as it takes the bundle to hydrate.
+  // Before the first paint: choose the opening page. The exported HTML is one
+  // file for every reader, so it cannot know the viewport or the URL hash and
+  // always paints the spread's first page. <head> marks the two cases where
+  // that is wrong — a narrow viewport, which opens on the identity page, and a
+  // deep link, which opens on its own section — and CSS holds the paper blank
+  // until this effect lands. Running before paint rather than after is the
+  // whole point: an effect would leave the wrong page on screen for as long as
+  // the bundle takes to hydrate.
   useBeforePaint(() => {
     const hash = window.location.hash.replace(/^#/, "");
-    if (!hash && !isDesktop()) {
-      setPos(0);
-      setAnimPage(0);
-      // nothing has been read yet, so no section is ticked off
-      setVisited(new Set());
-    }
-    document.documentElement.removeAttribute("data-nb-narrow");
-  }, []);
-
-  // first mount: resolve deep links, then schedule the cover auto-open
-  useEffect(() => {
-    const hash = window.location.hash.replace(/^#/, "");
     if (hash) {
-      const sec = sections.findIndex((s) => s.id === hash);
+      const sec = sections.findIndex((s2) => s2.id === hash);
       const target = hash === "hello" ? (isDesktop() ? 1 : 0) : sec >= 0 ? sectionStart[sec] : undefined;
       if (target !== undefined && target !== pos) {
-        // one-time sync from the URL hash
         setPos(target);
         setAnimPage(target);
         if (sec >= 0) {
@@ -384,8 +377,19 @@ export default function Notebook() {
           setVisited((prev) => new Set(prev).add(sec));
         }
       }
+    } else if (!isDesktop()) {
+      setPos(0);
+      setAnimPage(0);
+      // nothing has been read yet, so no section is ticked off
+      setVisited(new Set());
     }
+    const root = document.documentElement;
+    root.removeAttribute("data-nb-narrow");
+    root.removeAttribute("data-nb-await");
+  }, []);
 
+  // first mount: schedule the cover auto-open
+  useEffect(() => {
     if (visitedAtLoad) return undefined;
     if (reduced) {
       markVisitedStorage();

--- a/app/components/notebook/Notebook.tsx
+++ b/app/components/notebook/Notebook.tsx
@@ -365,6 +365,13 @@ export default function Notebook() {
           setVisited((prev) => new Set(prev).add(sec));
         }
       }
+    } else if (!isDesktop()) {
+      // a phone shows one page at a time, so it opens on the identity page;
+      // on a spread that page is the inside cover, with About facing it
+      setPos(0);
+      setAnimPage(0);
+      // nothing has been read yet, so no section is ticked off
+      setVisited(new Set());
     }
 
     if (visitedAtLoad) return undefined;
@@ -618,20 +625,11 @@ export default function Notebook() {
               {pos + 2 <= lastRight || (!isFiller(pos) && stepReal(pos, 1) !== null) ? (
                 <button
                   type="button"
-                  className="nb-corner nb-corner--next"
+                  className="nb-corner nb-corner--next hidden lg:block"
                   onClick={stepNext}
                   aria-label="Turn to the next page"
                 />
               ) : null}
-              {pos > 0 && (
-                <button
-                  type="button"
-                  className="nb-corner nb-corner--prev lg:hidden"
-                  onClick={stepPrev}
-                  aria-label="Turn back a page"
-                />
-              )}
-
               {flip && (
                 <React.Fragment key={flip.key}>
                   <motion.div

--- a/app/components/notebook/Notebook.tsx
+++ b/app/components/notebook/Notebook.tsx
@@ -622,7 +622,7 @@ export default function Notebook() {
                 );
               })}
 
-              {pos + 2 <= lastRight || (!isFiller(pos) && stepReal(pos, 1) !== null) ? (
+              {pos + 2 <= lastRight ? (
                 <button
                   type="button"
                   className="nb-corner nb-corner--next hidden lg:block"

--- a/app/components/notebook/Notebook.tsx
+++ b/app/components/notebook/Notebook.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { motion, useReducedMotion } from "motion/react";
 import resumeData from "../../../data/resumeData.json";
 import { generateResumePDFForPrint } from "../../utils/pdfGenerator";
@@ -52,6 +52,9 @@ function isDesktop() {
 }
 
 const emptySubscribe = () => () => {};
+
+/** layout effects do not run while prerendering, so fall back there */
+const useBeforePaint = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 /** hydration-safe read of the pre-paint "seen this session" marker */
 function useVisitedAtLoad() {
@@ -350,6 +353,22 @@ export default function Notebook() {
     }
   }, [pos, stepReal]);
 
+  // Before the first paint: a phone opens on the identity page, which on a
+  // spread is the inside cover rather than a page of its own. The exported HTML
+  // cannot know the viewport, so <head> marks narrow ones and CSS holds the
+  // right page until this runs — otherwise the opening page is visibly wrong
+  // for as long as it takes the bundle to hydrate.
+  useBeforePaint(() => {
+    const hash = window.location.hash.replace(/^#/, "");
+    if (!hash && !isDesktop()) {
+      setPos(0);
+      setAnimPage(0);
+      // nothing has been read yet, so no section is ticked off
+      setVisited(new Set());
+    }
+    document.documentElement.removeAttribute("data-nb-narrow");
+  }, []);
+
   // first mount: resolve deep links, then schedule the cover auto-open
   useEffect(() => {
     const hash = window.location.hash.replace(/^#/, "");
@@ -365,13 +384,6 @@ export default function Notebook() {
           setVisited((prev) => new Set(prev).add(sec));
         }
       }
-    } else if (!isDesktop()) {
-      // a phone shows one page at a time, so it opens on the identity page;
-      // on a spread that page is the inside cover, with About facing it
-      setPos(0);
-      setAnimPage(0);
-      // nothing has been read yet, so no section is ticked off
-      setVisited(new Set());
     }
 
     if (visitedAtLoad) return undefined;
@@ -602,7 +614,7 @@ export default function Notebook() {
                   <div
                     key={page.type === "content" ? `c-${page.section}-${page.col}` : `${page.type}-${i}`}
                     {...(startOfSection && sectionDef ? { id: `nb-panel-${sectionDef.id}`, role: "tabpanel", "aria-labelledby": `nb-tabd-${sectionDef.id}` } : {})}
-                    className="nb-sheetwrap"
+                    className={`nb-sheetwrap ${page.type === "me" ? "nb-sheetwrap--me" : ""}`}
                     data-active={i === rightShown ? "true" : "false"}
                     data-anim={i === pos && i === animPage ? "true" : "false"}
                     suppressHydrationWarning

--- a/app/components/notebook/Notebook.tsx
+++ b/app/components/notebook/Notebook.tsx
@@ -53,6 +53,15 @@ function isDesktop() {
 
 const emptySubscribe = () => () => {};
 
+/**
+ * A section's rendered content. Every page column, leaf face and measure
+ * flow shows one of these; memoising it means a navigation re-render
+ * touches none of them — the content is static per section.
+ */
+const SectionBody = React.memo(function SectionBody({ section }: { section: Section }) {
+  return <>{section.render()}</>;
+});
+
 /** layout effects do not run while prerendering, so fall back there */
 const useBeforePaint = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
@@ -503,7 +512,7 @@ export default function Notebook() {
     [sections],
   );
 
-  const identity = useCallback(
+  const identityEl = useMemo(
     () => (
       <IdentityPage
         personalInfo={resumeData.personalInfo}
@@ -536,19 +545,22 @@ export default function Notebook() {
       ...(metrics ? { "--nb-colw": `${metrics.colw}px`, "--nb-colh": `${metrics.colh}px` } : {}),
     }) as React.CSSProperties;
 
-  const renderContentInner = (page: Extract<PageDef, { type: "content" }>) => (
-    <div className="nb-sheet-inner nb-pageview">
-      <div className="nb-colflow" style={colStyle(page.col)}>
-        {sections[page.section]?.render()}
+  const renderContentInner = (page: Extract<PageDef, { type: "content" }>) => {
+    const section = sections[page.section];
+    return (
+      <div className="nb-sheet-inner nb-pageview">
+        <div className="nb-colflow" style={colStyle(page.col)}>
+          {section && <SectionBody section={section} />}
+        </div>
       </div>
-    </div>
-  );
+    );
+  };
 
   /** the identity page flows across columns too, so it never scrolls */
   const renderIdentityInner = (col: number) => (
     <div className="nb-sheet-inner nb-pageview">
       <div className="nb-colflow" style={colStyle(col)}>
-        {identity()}
+        {identityEl}
       </div>
     </div>
   );
@@ -711,16 +723,25 @@ export default function Notebook() {
           {/* hidden measuring rig: how many page-columns does each flow need?
               The identity page is measured first, then every section. */}
           <div ref={measureRef} className="nb-measure" aria-hidden="true" inert>
-            {metrics &&
-              [{ id: "hello", render: identity }, ...sections].map((s) => (
+            {metrics && (
+              <>
                 <div
-                  key={s.id}
                   className="nb-measure-flow"
                   style={{ "--nb-colw": `${metrics.colw}px`, "--nb-colh": `${metrics.colh}px` } as React.CSSProperties}
                 >
-                  {s.render()}
+                  {identityEl}
                 </div>
-              ))}
+                {sections.map((s) => (
+                  <div
+                    key={s.id}
+                    className="nb-measure-flow"
+                    style={{ "--nb-colw": `${metrics.colw}px`, "--nb-colh": `${metrics.colh}px` } as React.CSSProperties}
+                  >
+                    <SectionBody section={s} />
+                  </div>
+                ))}
+              </>
+            )}
           </div>
         </div>
       </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -89,11 +89,12 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        {/* Marks same-session visitors before first paint so the notebook renders already-open
-            (the cover animation plays once per browser session). */}
+        {/* Runs before first paint: marks same-session visitors so the cover animation plays
+            once per session, and marks narrow viewports so a phone does not paint the
+            spread's opening page before React picks its own. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{if(sessionStorage.getItem("nb-open"))document.documentElement.setAttribute("data-nb-visited","")}catch(e){}`,
+            __html: `try{var d=document.documentElement;if(sessionStorage.getItem("nb-open"))d.setAttribute("data-nb-visited","");if(!location.hash&&!matchMedia("(min-width: 1024px)").matches)d.setAttribute("data-nb-narrow","")}catch(e){}`,
           }}
         />
       </head>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -94,7 +94,7 @@ export default function RootLayout({
             spread's opening page before React picks its own. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{var d=document.documentElement;if(sessionStorage.getItem("nb-open"))d.setAttribute("data-nb-visited","");if(!location.hash&&!matchMedia("(min-width: 1024px)").matches)d.setAttribute("data-nb-narrow","")}catch(e){}`,
+            __html: `try{var d=document.documentElement;if(sessionStorage.getItem("nb-open"))d.setAttribute("data-nb-visited","");if(location.hash)d.setAttribute("data-nb-await","");else if(!matchMedia("(min-width: 1024px)").matches)d.setAttribute("data-nb-narrow","")}catch(e){}`,
           }}
         />
       </head>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -94,7 +94,7 @@ export default function RootLayout({
             spread's opening page before React picks its own. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{var d=document.documentElement;if(sessionStorage.getItem("nb-open"))d.setAttribute("data-nb-visited","");if(location.hash)d.setAttribute("data-nb-await","");else if(!matchMedia("(min-width: 1024px)").matches)d.setAttribute("data-nb-narrow","")}catch(e){}`,
+            __html: `try{var d=document.documentElement;if(sessionStorage.getItem("nb-open"))d.setAttribute("data-nb-visited","");if(location.hash)d.setAttribute("data-nb-await",location.hash.slice(1).replace(/[^a-zA-Z-]/g,""));else if(!matchMedia("(min-width: 1024px)").matches)d.setAttribute("data-nb-narrow","")}catch(e){}`,
           }}
         />
       </head>

--- a/app/notebook.css
+++ b/app/notebook.css
@@ -656,7 +656,7 @@
   filter: brightness(1.06);
 }
 
-.nb-tab-d[aria-selected="true"] {
+html:not([data-nb-await]):not([data-nb-narrow]) .nb-tab-d[aria-selected="true"] {
   width: 96px;
   filter: brightness(1.08) saturate(1.05);
   box-shadow:
@@ -669,7 +669,7 @@
   filter: brightness(0.88) saturate(0.92);
 }
 
-.dark .nb-tab-d[aria-selected="true"],
+html.dark:not([data-nb-await]):not([data-nb-narrow]) .nb-tab-d[aria-selected="true"],
 .dark .nb-tab-d:hover {
   filter: brightness(1) saturate(1);
 }
@@ -710,7 +710,7 @@
   transition: transform 0.2s ease, filter 0.2s ease;
 }
 
-.nb-tab-m[aria-selected="true"] {
+html:not([data-nb-await]):not([data-nb-narrow]) .nb-tab-m[aria-selected="true"] {
   transform: translateY(0);
   filter: brightness(1.07);
 }
@@ -719,7 +719,7 @@
   filter: brightness(0.85) saturate(0.9);
 }
 
-.dark .nb-tab-m[aria-selected="true"] {
+html.dark:not([data-nb-await]):not([data-nb-narrow]) .nb-tab-m[aria-selected="true"] {
   filter: brightness(1);
 }
 
@@ -1607,14 +1607,6 @@ html[data-nb-narrow] .nb-sheetwrap--me {
   visibility: visible;
 }
 
-html[data-nb-narrow] .nb-tabs-m .nb-tab-m[aria-selected="true"] {
-  transform: translateY(5px);
-}
-
-html[data-nb-narrow] .nb-tabs-m .nb-tab-m:first-child {
-  transform: translateY(0);
-}
-
 /* A deep link cannot be resolved before React knows how the sections
    paginate, so the paper stays blank rather than showing the wrong
    section — the notebook is on screen, just not yet written on. */
@@ -1622,10 +1614,71 @@ html[data-nb-await] .nb-sheetwrap {
   visibility: hidden;
 }
 
-html[data-nb-await] .nb-tabs-m .nb-tab-m[aria-selected="true"] {
-  transform: translateY(5px);
+/* ============================================================
+   Pre-paint tab selection
+   The exported HTML marks About selected, but which tab is truly
+   current depends only on the URL hash, which <head> copies onto
+   <html> before first paint. While the hold is up the selected
+   look is suppressed and re-applied here to the right tab, so the
+   highlight never visits About on the way. React removes the
+   markers before its own first paint.
+   ============================================================ */
+
+html[data-nb-await="about"] #nb-tabd-about,
+html[data-nb-await="wins"] #nb-tabd-wins,
+html[data-nb-await="skills"] #nb-tabd-skills,
+html[data-nb-await="work"] #nb-tabd-work,
+html[data-nb-await="projects"] #nb-tabd-projects,
+html[data-nb-await="school"] #nb-tabd-school,
+html[data-nb-await="say-hi"] #nb-tabd-say-hi,
+html[data-nb-await="hello"] #nb-tabd-about {
+  width: 96px;
+  filter: brightness(1.08) saturate(1.05);
+  box-shadow:
+    inset 0 1.5px 0 rgba(255, 255, 255, 0.55),
+    inset 0 -2px 3px rgba(0, 0, 0, 0.08),
+    3px 4px 9px rgba(20, 10, 0, 0.32);
 }
 
-html[data-nb-await] .nb-tabs-d .nb-tab-d[aria-selected="true"] {
-  width: 78px;
+html[data-nb-await="about"] #nb-tabm-about,
+html[data-nb-await="wins"] #nb-tabm-wins,
+html[data-nb-await="skills"] #nb-tabm-skills,
+html[data-nb-await="work"] #nb-tabm-work,
+html[data-nb-await="projects"] #nb-tabm-projects,
+html[data-nb-await="school"] #nb-tabm-school,
+html[data-nb-await="say-hi"] #nb-tabm-say-hi,
+html[data-nb-await="hello"] #nb-tabm-hello,
+html[data-nb-narrow] #nb-tabm-hello {
+  transform: translateY(0);
+  filter: brightness(1.07);
+}
+
+html.dark[data-nb-await="about"] #nb-tabd-about,
+html.dark[data-nb-await="wins"] #nb-tabd-wins,
+html.dark[data-nb-await="skills"] #nb-tabd-skills,
+html.dark[data-nb-await="work"] #nb-tabd-work,
+html.dark[data-nb-await="projects"] #nb-tabd-projects,
+html.dark[data-nb-await="school"] #nb-tabd-school,
+html.dark[data-nb-await="say-hi"] #nb-tabd-say-hi,
+html.dark[data-nb-await="hello"] #nb-tabd-about {
+  filter: brightness(1) saturate(1.05);
+}
+
+html.dark[data-nb-await="about"] #nb-tabm-about,
+html.dark[data-nb-await="wins"] #nb-tabm-wins,
+html.dark[data-nb-await="skills"] #nb-tabm-skills,
+html.dark[data-nb-await="work"] #nb-tabm-work,
+html.dark[data-nb-await="projects"] #nb-tabm-projects,
+html.dark[data-nb-await="school"] #nb-tabm-school,
+html.dark[data-nb-await="say-hi"] #nb-tabm-say-hi,
+html.dark[data-nb-await="hello"] #nb-tabm-hello,
+html.dark[data-nb-narrow] #nb-tabm-hello {
+  filter: brightness(1);
+}
+
+/* the left paper is not written on either until the page is known */
+html[data-nb-await] .nb-cover-back .nb-sheet-inner,
+html[data-nb-await] .nb-cover-back .nb-idclip,
+html[data-nb-await] .nb-leftpage {
+  visibility: hidden;
 }

--- a/app/notebook.css
+++ b/app/notebook.css
@@ -1589,3 +1589,28 @@ html[data-nb-visited] .nb-leftpage {
     overflow: visible;
   }
 }
+
+/* ============================================================
+   Pre-paint opening page (narrow viewports)
+   The exported HTML opens on the spread's first page, which is
+   correct for a two-page layout but wrong for a phone, where the
+   identity page is a page of its own rather than the inside cover.
+   The marker is set in <head> and removed by React before the
+   first paint, so these rules only ever cover that gap.
+   ============================================================ */
+
+html[data-nb-narrow] .nb-sheetwrap[data-active="true"] {
+  visibility: hidden;
+}
+
+html[data-nb-narrow] .nb-sheetwrap--me {
+  visibility: visible;
+}
+
+html[data-nb-narrow] .nb-tabs-m .nb-tab-m[aria-selected="true"] {
+  transform: translateY(5px);
+}
+
+html[data-nb-narrow] .nb-tabs-m .nb-tab-m:first-child {
+  transform: translateY(0);
+}

--- a/app/notebook.css
+++ b/app/notebook.css
@@ -1614,3 +1614,18 @@ html[data-nb-narrow] .nb-tabs-m .nb-tab-m[aria-selected="true"] {
 html[data-nb-narrow] .nb-tabs-m .nb-tab-m:first-child {
   transform: translateY(0);
 }
+
+/* A deep link cannot be resolved before React knows how the sections
+   paginate, so the paper stays blank rather than showing the wrong
+   section — the notebook is on screen, just not yet written on. */
+html[data-nb-await] .nb-sheetwrap {
+  visibility: hidden;
+}
+
+html[data-nb-await] .nb-tabs-m .nb-tab-m[aria-selected="true"] {
+  transform: translateY(5px);
+}
+
+html[data-nb-await] .nb-tabs-d .nb-tab-d[aria-selected="true"] {
+  width: 78px;
+}


### PR DESCRIPTION
Two phone-only problems with the notebook's navigation.

## 1. A phone opened on About, not on the identity page

The opening position was hardcoded to page 1. That is right on a desktop spread — there the identity page **is** the inside cover, so page 1 is the facing page and the reader sees both at once. A phone shows one page at a time, so page 1 skipped the identity page altogether and the notebook opened on About.

Phones now open on page 0. A URL hash still takes precedence, so a shared `#work` link still lands on Work.

The `visited` set is cleared in the same branch. It was seeded with About on the assumption that About is where the reader starts, which would have shown About already ticked off in the checklist before they had been there.

## 2. The page-turn corners are desktop-only

The folded corners are a hover affordance: they stay invisible until the pointer is over the page, then grow under it. A touch screen has no hover, so a CSS fallback made them permanently visible on phones — a dog-ear on every page with nothing to explain it. Tabs and swipe already cover navigation there, so the corners are now `lg`-only.

`stepPrev` is still wired to swipe and the arrow keys, so nothing else loses a route.

## Verification

Measured at three widths, checking the first page, how many corners are actually visible (computed style and box size, not just presence), and whether swipe still turns pages:

| | first page | corners visible | swipe |
|---|---|---|---|
| phone 390 | identity | 0 | works |
| tablet 768 | identity | 0 | works |
| desktop 1280 | About (identity on the cover) | 1 | n/a |
| phone 390 at `#work` | Where I've worked | 0 | works |

No console errors. `tsc --noEmit`, `eslint app` and `next build` (static export) are clean.
